### PR TITLE
Implement ERC1155 supply extension

### DIFF
--- a/contracts/Frencapital.sol
+++ b/contracts/Frencapital.sol
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Supply.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract Frencapital is Ownable, ERC1155 {
+contract Frencapital is Ownable, ERC1155Supply {
+
     uint256 public constant FREN = 0;
     uint256 public constant FOUN = 1;
     uint8 public participants = 0;

--- a/test/index.ts
+++ b/test/index.ts
@@ -91,5 +91,14 @@ describe("Frencapital", function () {
       expect(await frencapital.participants()).to.equal(0);
     });
   });
+
+  context("share calculation", () => {
+    it("Should track total supply per token", async () => {
+      const mintTx = await frencapital.mint(addr1.address, 1000);
+      await mintTx.wait();
+      expect(await frencapital.totalSupply(0)).to.equal(1000);
+      expect(await frencapital.totalSupply(1)).to.equal(1);
+    });
+  });
   
 });


### PR DESCRIPTION
Allows us to track total supply per token (and easily calc share)